### PR TITLE
Added pagination for top coins in Crypto.jsx (#41)

### DIFF
--- a/src/pages/Crypto.jsx
+++ b/src/pages/Crypto.jsx
@@ -18,45 +18,76 @@
  *  - [ ] Dark mode adaptive coloring for charts
  *  - [ ] Extract to service + custom hook (useCryptoMarkets)
  */
-import { useEffect, useState } from 'react';
-import Loading from '../components/Loading.jsx';
-import ErrorMessage from '../components/ErrorMessage.jsx';
-import Card from '../components/Card.jsx';
+import { useEffect, useState } from "react";
+import Loading from "../components/Loading.jsx";
+import ErrorMessage from "../components/ErrorMessage.jsx";
+import Card from "../components/Card.jsx";
 
 export default function Crypto() {
   const [coins, setCoins] = useState([]);
-  const [query, setQuery] = useState('');
+  const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
 
-  useEffect(() => { fetchCoins(); }, []);
+  useEffect(() => {
+    fetchCoins();
+  }, [page]);
 
   async function fetchCoins() {
     try {
-      setLoading(true); setError(null);
-      const res = await fetch('https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=50&page=1&sparkline=false');
-      if (!res.ok) throw new Error('Failed to fetch');
+      setLoading(true);
+      setError(null);
+      const res = await fetch(
+        `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=50&page=${page}&sparkline=false`
+      );
+      if (!res.ok) throw new Error("Failed to fetch");
       const json = await res.json();
       setCoins(json);
-    } catch (e) { setError(e); } finally { setLoading(false); }
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
   }
 
-  const filtered = coins.filter(c => c.name.toLowerCase().includes(query.toLowerCase()));
+  const filtered = coins.filter((c) =>
+    c.name.toLowerCase().includes(query.toLowerCase())
+  );
 
   return (
     <div>
       <h2>Cryptocurrency Tracker</h2>
-      <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Search coin" />
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search coin"
+      />
+
       {loading && <Loading />}
       <ErrorMessage error={error} />
       <div className="grid">
-        {filtered.map(c => (
-          <Card key={c.id} title={c.name} footer={<span>${c.current_price}</span>}>
+        {filtered.map((c) => (
+          <Card
+            key={c.id}
+            title={c.name}
+            footer={<span>${c.current_price}</span>}
+          >
             <p>Market Cap: ${c.market_cap.toLocaleString()}</p>
             <p>24h: {c.price_change_percentage_24h?.toFixed(2)}%</p>
             {/* TODO: Add mini sparkline chart */}
           </Card>
         ))}
+      </div>
+
+      <div className="pagination">
+        <button onClick={() => setPage((p) => p - 1)} disabled={page === 1}>
+          Previous
+        </button>
+
+        <span>Page {page}</span>
+
+        <button onClick={() => setPage((p) => p + 1)}>Next</button>
       </div>
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -412,3 +412,35 @@ blockquote {
 @media (max-width: 640px) {
   .weather-inner { padding: 1rem; }
 }
+
+
+/**Pagination **/
+
+.pagination {
+  width: 100%;
+  display: flex;
+  justify-content: center;  
+  align-items: center;     
+  margin-top: 20px;         
+  gap: 15px;           
+}
+
+.pagination button {
+  padding: 8px 16px;
+  border-radius: 5px;
+  border: none;
+  background-color: #007bff;
+  color: white;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.pagination button:hover {
+  background-color: #0056b3;
+}
+
+.pagination button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
# Add Pagination for Top Coins in Crypto.jsx (#41)

## Description
This PR implements **pagination** for the cryptocurrency dashboard in `Crypto.jsx`.  
Now, users can navigate through multiple pages of top coins, 50 coins per page, using **Previous** and **Next** buttons.

## Changes Made
- Added a `page` state to track the current page.
- Updated `fetchCoins` function to fetch 50 coins per page based on the `page` state.
- Added **Previous** / **Next** buttons to navigate pages.
- Centered pagination below the coin cards using standard CSS.
- Styled buttons with hover and disabled states for better user experience.

## Screenshots
<img width="1868" height="882" alt="pagination2" src="https://github.com/user-attachments/assets/fe620b22-e552-4429-a422-4b1e12659a55" />
<img width="1883" height="883" alt="pagination1" src="https://github.com/user-attachments/assets/90ce8959-52f9-4a38-b333-f3bb9df3d432" />
 

## How to Test
1. Run the app.
2. Observe the coin list displays 50 coins per page.
3. Use the **Next** button to navigate to the next set of coins.
4. Use the **Previous** button to navigate back.
5. Check that **Previous** button is disabled on the first page.

