### PR TITLE
integrate Recharts and add hourly forecast chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.27.0",
-    "leaflet": "^1.9.4",
-    "react-leaflet": "^4.2.1"
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
fixes #20 
Added an hourly forecast visualization using Recharts. The chart displays temperature and “feels like” trends throughout the day with gradient styling, tooltips, and responsive design.

Changes:
Integrated Recharts library
Added hourly forecast area chart in Weather Dashboard
Improved data mapping for hourly weather data
Preview: Displays an interactive, responsive temperature chart under the 3-day forecast section.

Screenshot:
<img width="1115" height="411" alt="image" src="https://github.com/user-attachments/assets/694b1370-ce8a-4777-a827-793323af188b" />
