### PR TITLE
Display feels-like temperature and wind speed in current weather card

### DIFF
--- a/src/pages/Weather.jsx
+++ b/src/pages/Weather.jsx
@@ -280,6 +280,14 @@ export default function Weather() {
                   {displayTemp(Number(current.temp_C))}°{unit}
                 </span>
               </p>
+
+              <p>
+                <strong>Feels Like:</strong>{" "}
+                {displayTemp(Number(current.FeelsLikeC))}°{unit}
+              </p>
+              <p>
+                <strong>Wind Speed:</strong> {current.windspeedKmph} km/h
+              </p>
               <p>
                 <strong>Humidity:</strong> {current.humidity}%
               </p>


### PR DESCRIPTION
Fixes #12 

Added feels-like temperature and wind speed details in the current weather section for improved weather insights.

Screenshot:
<img width="1470" height="836" alt="image" src="https://github.com/user-attachments/assets/f0a5fb42-0a5a-46ec-bf20-a0b5ccc3a99d" />
