### PR TITLE
api cors & rate limiting fix

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,14 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+    server: {
+    proxy: {
+      '/api': {
+        target: 'http://api.open-notify.org',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    }
+  }
+
 });


### PR DESCRIPTION
Fixes #52 

I found a solution to this issue:  
1. Cross-origin error.  
2. Rate limiting (429) – this API has a fixed request limit, so when too many people use it, it sometimes goes down.  

I added an artificial delay between the second call. Another alternative solution I thought of is to send raw data to the user if the API is busy, and then provide the actual fetched data once the API is free.  


### Before:

<img width="1920" height="1080" alt="Screenshot (870)" src="https://github.com/user-attachments/assets/37780feb-dc5a-44b2-af8f-b7c6660bcf28" />


### After:


https://github.com/user-attachments/assets/2d4ce9b6-ff54-43e8-a989-97dcc8aca9cb


