### PR TITLE
feat: add github profile analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_OMDB_API_KEY=your_api_key_here
 VITE_WEATHER_API_KEY=your_api_key_here
+VITE_GITHUB_TOKEN=your_github_personal_access_token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,13 @@ Task Flow Board:
 - Implement drag-to-connect nodes feature
 - Add task dependencies validation
 
+GitHub Profile Analyzer:
+- View GitHub profile stats, repositories, and pull request activity at a glance
+- Compare two profiles side-by-side
+- Language usage and repo stats charts
+- Contribution calendar visualization
+- Error handling for missing/invalid tokens
+
 Global Enhancements:
 
 - Extract API calls into services folder

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A collection of interactive dashboards that fetch and display data from **free, 
 | 🐶🐱 Pets             | [Dog CEO](https://dog.ceo/dog-api/) + [Cataas](https://cataas.com/#/)                                   | Random cute dog and cat images                    |
 | 🦠 COVID-19 Tracker   | [COVID19 API](https://covid19api.com/)                                                                  | Track pandemic stats and trends globally          |
 | 📋 Task Flow Board    | [React Flow](https://reactflow.dev/)                                                                    | Visual task management with draggable nodes       |
+| 🧑‍💻 GitHub Profile Analyzer | [GitHub GraphQL API](https://docs.github.com/en/graphql) | Discover, analyze, and compare GitHub profiles with advanced stats and insights |
 
 ---
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ import Navbar from './components/Navbar.jsx';
 import ContributorsWall from './pages/Contributors.jsx'
 import Pokedex from './pages/Pokedex.jsx';
 import TaskFlowBoard from './pages/TaskFlowBoard.jsx';
+import GitHubProfileAnalyzer from './pages/GitHubProfileAnalyzer.jsx';
 
 // TODO: Extract theme state into context (see todo 5).
 import { useState, useEffect } from 'react';
@@ -84,6 +85,7 @@ export default function App() {
             <Route path="/contributors" element={<ContributorsWall />} />    
             <Route path="/pokedex" element={<Pokedex />} />  
             <Route path="/taskflow" element={<TaskFlowBoard />} />
+            <Route path="/github-profile-analyzer" element={<GitHubProfileAnalyzer />} />
         </Routes>
       </main>
     </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -17,6 +17,7 @@ export default function Navbar({ theme, toggleTheme }) {
         <li><NavLink to="/pets">Pets</NavLink></li>
         <li><NavLink to="/covid">COVID-19</NavLink></li>
         <li><NavLink to="/taskflow">TaskFlow</NavLink></li>
+        <li><NavLink to="/github-profile-analyzer">GitHub Profile Analyzer</NavLink></li>
         <li className="theme-item">
           <button 
             className="theme-toggle" 

--- a/src/pages/GitHubProfileAnalyzer.css
+++ b/src/pages/GitHubProfileAnalyzer.css
@@ -1,0 +1,1209 @@
+/* Token Modal Styles */
+.token-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(36, 36, 37, 0.7);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.token-modal {
+  background: linear-gradient(135deg, #fff 80%, #4ecdc4 100%);
+  color: #333;
+  padding: 32px 28px 24px 28px;
+  border-radius: 18px;
+  box-shadow: 0 8px 32px rgba(36, 36, 37, 0.18);
+  min-width: 340px;
+  max-width: 90vw;
+  text-align: center;
+  animation: fadeIn 0.4s ease;
+}
+
+.token-modal h2 {
+  font-size: 1.7rem;
+  margin-bottom: 10px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.token-modal p {
+  color: #444;
+  margin-bottom: 18px;
+}
+
+.token-modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.token-modal .search-input {
+  padding: 12px 18px;
+  border-radius: 8px;
+  border: 1px solid #4ecdc4;
+  background: #f7f7f7;
+  color: #333;
+  font-size: 1rem;
+  outline: none;
+  margin-bottom: 8px;
+}
+
+.token-modal .search-input::placeholder {
+  color: #888;
+}
+
+.token-modal .search-button {
+  padding: 12px 0;
+  border-radius: 8px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.18);
+  transition: background 0.3s, transform 0.2s;
+}
+
+.token-modal .search-button:hover {
+  background: linear-gradient(45deg, #ff5252, #3dbdb5);
+  transform: scale(1.04);
+}
+
+.token-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(36, 36, 37, 0.7);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.token-modal {
+  background: linear-gradient(135deg, #fff 80%, #4ecdc4 100%);
+  color: #333;
+  padding: 32px 28px 24px 28px;
+  border-radius: 18px;
+  box-shadow: 0 8px 32px rgba(36, 36, 37, 0.18);
+  min-width: 370px;
+  max-width: 90vw;
+  text-align: center;
+  animation: fadeIn 0.4s ease;
+}
+
+.token-modal h2 {
+  font-size: 1.7rem;
+  margin-bottom: 10px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.token-modal p {
+  color: #444;
+  margin-bottom: 18px;
+}
+
+.token-modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.token-modal .search-input {
+  padding: 12px 2px;
+  border-radius: 8px;
+  border: 1px solid #4ecdc4;
+  background: #f7f7f7;
+  color: #333;
+  font-size: 1rem;
+  outline: none;
+  margin-bottom: 8px 8px;
+}
+
+.token-modal .search-input::placeholder {
+  color: #888;
+}
+
+.token-modal .search-button {
+  padding: 12px 0;
+  border-radius: 8px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.18);
+  transition: background 0.3s, transform 0.2s;
+}
+
+.token-modal .search-button:hover {
+  background: linear-gradient(45deg, #ff5252, #3dbdb5);
+  transform: scale(1.04);
+}
+
+.github-profile-analyzer {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #242425 0%, #764ba2 100%);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #333;
+  padding: 20px;
+  animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.hero-section {
+  text-align: center;
+  margin-bottom: 40px;
+  padding: 20px 20px 60px 20px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 70vh;
+}
+
+.main-title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: titleGlow 2s ease-in-out infinite alternate;
+}
+
+@keyframes titleGlow {
+  from { filter: brightness(1); }
+  to { filter: brightness(1.2); }
+}
+
+.subtitle {
+  font-size: 1.2rem;
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: 30px;
+}
+
+.search-container {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.search-bar, .compare-search {
+  display: flex;
+  margin-bottom: 20px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 50px;
+  padding: 5px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  transition: all 0.3s ease;
+}
+
+.search-bar:hover, .compare-search:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.search-input {
+  flex: 1;
+  padding: 15px 20px;
+  border: none;
+  background: transparent;
+  color: white;
+  font-size: 1rem;
+  border-radius: 45px;
+  outline: none;
+}
+
+.search-input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.search-button {
+  padding: 15px 30px;
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  color: white;
+  border: none;
+  border-radius: 45px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.4);
+}
+
+.search-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba(255, 107, 107, 0.6);
+}
+
+.compare-toggle {
+  margin-bottom: 20px;
+  color: white;
+  font-weight: 500;
+  text-align: center;
+}
+
+.compare-toggle input {
+  margin-right: 10px;
+  transform: scale(1.2);
+}
+
+.content-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.tabs {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 30px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 15px;
+  padding: 10px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.tabs button {
+  padding: 12px 24px;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  margin: 0 5px;
+}
+
+.tabs button:hover, .tabs button.active {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.tab-content {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 20px;
+  padding: 30px;
+  margin-bottom: 30px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  animation: slideUp 0.5s ease-out;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(30px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.tab-content h3, .tab-content h4 {
+  color: #333;
+  margin-bottom: 15px;
+}
+
+.tab-content p, .tab-content li, .tab-content span {
+  color: #555;
+}
+
+.tab-content a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.tab-content a:hover {
+  text-decoration: underline;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 30px;
+  background: linear-gradient(45deg, #f8a7a7, #44aba4);
+  border-radius: 15px;
+  padding: 30px;
+  color: white;
+  box-shadow: 0 8px 32px rgba(245, 87, 108, 0.3);
+  transition: all 0.3s ease;
+}
+
+.profile-header:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 40px rgba(245, 87, 108, 0.4);
+}
+
+.profile-header.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  box-shadow: 0 8px 32px rgba(79, 172, 254, 0.3);
+}
+
+.profile-avatar {
+  position: relative;
+  margin-right: 30px;
+}
+
+.avatar-image {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  transition: all 0.3s ease;
+}
+
+.avatar-image:hover {
+  transform: scale(1.1);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.avatar-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.3));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.profile-avatar:hover .avatar-overlay {
+  opacity: 1;
+}
+
+.profile-info h2 {
+  margin: 0 0 5px 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.profile-username {
+  margin: 0 0 15px 0;
+  opacity: 0.8;
+  font-size: 1.1rem;
+}
+
+.profile-bio {
+  margin: 0 0 20px 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.profile-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.detail-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.detail-icon {
+  font-size: 1.2rem;
+}
+
+.profile-link {
+  color: white;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 8px 16px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 20px;
+  transition: all 0.3s ease;
+}
+
+.profile-link:hover {
+  background: rgba(255, 255, 255, 0.3);
+  transform: translateY(-2px);
+}
+
+.profile-stats {
+  display: flex;
+  gap: 30px;
+}
+
+.stat-card {
+  text-align: center;
+}
+
+.stat-number {
+  display: block;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+}
+
+.stat-label {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+.stats-panel {
+  margin-bottom: 30px;
+  color: white;
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(127, 149, 250, 0.3);
+}
+
+.stats-panel.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  box-shadow: 0 8px 32px rgba(240, 147, 251, 0.3);
+}
+
+.panel-title {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+  text-align: center;
+  color: white;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 20px;
+  margin-bottom: 30px;
+}
+
+.stat-item {
+  text-align: center;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(57, 56, 56, 0.137);
+  transition: all 0.3s ease;
+}
+
+.stat-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.stat-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 5px;
+  color: white;
+}
+
+.stat-desc {
+  font-size: 0.9rem;
+  opacity: 0.8;
+  color: white;
+}
+
+.highlight-repo {
+  margin-bottom: 20px;
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.highlight-repo h4 {
+  margin: 0 0 10px 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: rgb(26, 26, 26);
+}
+
+.highlight-repo p {
+  color: rgb(26, 26, 26);
+}
+
+.top-languages {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 20px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.top-languages h4 {
+  margin: 0 0 15px 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: rgb(26, 26, 26);
+}
+
+.top-languages ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.lang-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.lang-item:last-child {
+  border-bottom: none;
+}
+
+.lang-name {
+  font-weight: 600;
+  color: white;
+}
+
+.lang-count {
+  opacity: 0.8;
+  color: white;
+}
+
+.language-chart {
+  margin-bottom: 30px;
+  background: linear-gradient(135deg, #f5f6fa 0%, #f2eef5 100%);
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.language-chart.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  color: rgb(48, 48, 48);
+}
+
+.chart-title {
+  text-align: center;
+  margin-bottom: 30px;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.chart-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.bar-chart .bar {
+  transition: all 0.3s ease;
+}
+
+.bar-chart .bar:hover {
+  opacity: 0.8;
+  transform: scaleY(1.1);
+}
+
+.bar-label {
+  font-size: 12px;
+  fill: #333;
+}
+
+.language-chart.compare .bar-label {
+  fill: rgb(61, 61, 61);
+}
+
+.bar-value {
+  font-size: 10px;
+  fill: #666;
+}
+
+.language-chart.compare .bar-value {
+  fill: rgba(69, 69, 69, 0.8);
+}
+
+.legend {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 15px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.repo-list {
+  margin-bottom: 30px;
+  background: white;
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.repo-list.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.control-group label {
+  font-weight: 600;
+  color: #555;
+}
+
+.control-select {
+  padding: 8px 12px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  background: white;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.control-select:hover, .control-select:focus {
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+/* Dark mode styles */
+.theme-dark .control-select {
+  background: #333;
+  color: white;
+  border-color: #555;
+}
+
+.theme-dark .control-select:hover, .theme-dark .control-select:focus {
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+}
+
+.theme-dark .control-select option {
+  background: #333;
+  color: white;
+}
+
+.repo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.repo-card {
+  background: #f8f9fa;
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+  transition: all 0.3s ease;
+  border: 1px solid #e9ecef;
+}
+
+.repo-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  border-color: #667eea;
+}
+
+.repo-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.repo-name {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.repo-name a {
+  color: #333;
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.repo-name a:hover {
+  color: #667eea;
+}
+
+.repo-language {
+  background: #667eea;
+  color: white;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.repo-description {
+  color: #666;
+  margin-bottom: 15px;
+  line-height: 1.5;
+}
+
+.repo-stats {
+  display: flex;
+  gap: 15px;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.repo-stat {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.activity-feed {
+  margin-bottom: 30px;
+  background: white;
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.activity-feed.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  color: white;
+}
+
+.activity-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 30px;
+}
+
+.activity-section h4 {
+  margin: 0 0 15px 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.activity-feed.compare .activity-section h4 {
+  color: white;
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.activity-item {
+  padding: 10px 0;
+  border-bottom: 1px solid #eee;
+  transition: all 0.3s ease;
+}
+
+.activity-item:hover {
+  background: rgba(102, 126, 234, 0.05);
+  padding-left: 10px;
+}
+
+.activity-feed.compare .activity-item:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.activity-link {
+  color: #667eea;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.3s ease;
+}
+
+.activity-link:hover {
+  color: #4c63d2;
+}
+
+.activity-feed.compare .activity-link {
+  color: #4c4c4d;
+}
+
+.activity-date, .activity-count {
+  color: #666;
+  font-size: 0.9rem;
+  margin-left: 10px;
+}
+
+.activity-feed.compare .activity-date, .activity-feed.compare .activity-count {
+  color: #747475;
+}
+
+.activity-repo {
+  font-weight: 500;
+}
+
+.contribution-calendar {
+  margin-bottom: 30px;
+  background: white;
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.contribution-calendar.compare {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  color: white;
+}
+
+.calendar-total {
+  text-align: center;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+.calendar-grid {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 20px;
+  overflow-x: auto;
+}
+
+.calendar-week {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.calendar-day {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  transition: all 0.3s ease;
+}
+
+.calendar-day:hover {
+  transform: scale(1.5);
+}
+
+.calendar-day.none {
+  background: #ebedf0;
+}
+
+.calendar-day.low {
+  background: #9be9a8;
+}
+
+.calendar-day.medium {
+  background: #40c463;
+}
+
+.calendar-day.high {
+  background: #30a14e;
+}
+
+.calendar-day.very-high {
+  background: #216e39;
+}
+
+.calendar-legend {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 0.9rem;
+}
+
+.legend-colors {
+  display: flex;
+  gap: 2px;
+}
+
+.legend-colors div {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.compare-profiles {
+  background: linear-gradient(135deg, #8bc4f5 0%, #78ecf2 100%);
+  border-radius: 15px;
+  padding: 30px;
+  box-shadow: 0 8px 32px rgba(102, 126, 234, 0.3);
+}
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 30px;
+}
+
+.compare-item {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 20px;
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.compare-item h4 {
+  margin: 0 0 15px 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: rgb(73, 73, 73);
+}
+
+.compare-stats p {
+  margin: 8px 0;
+  font-size: 0.95rem;
+  color: rgb(67, 67, 67);
+}
+
+.compare-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  margin-top: 20px;
+}
+
+.profile-section {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: all 0.3s ease;
+}
+
+.profile-section:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+}
+
+.profile-section h3 {
+  color: #333 !important;
+  margin-bottom: 15px;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.profile-section h4 {
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.profile-section p, .profile-section li, .profile-section span {
+  color: #555;
+}
+
+.profile-section a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.profile-section a:hover {
+  text-decoration: underline;
+}
+
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.loading-spinner {
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 200px;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 10px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(45deg, #ff5252, #3dbdb5);
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 200px;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 10px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Print styles */
+@media print {
+  .github-profile-analyzer {
+    background: white;
+    color: black;
+  }
+
+  .hero-section, .tabs, .tab-content {
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+
+  .search-container, .tabs {
+    display: none;
+  }
+}
+
+/* High contrast mode */
+@media (prefers-contrast: high) {
+  .github-profile-analyzer {
+    background: white;
+    color: black;
+  }
+
+  .hero-section, .tab-content {
+    background: white;
+    border: 2px solid black;
+  }
+
+  .profile-header, .stats-panel {
+    background: #f0f0f0;
+    color: black;
+    border: 2px solid black;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+.compare-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  margin-top: 20px;
+}
+
+.profile-section {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 15px;
+  padding: 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  transition: all 0.3s ease;
+}
+
+.profile-section:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+}
+
+.profile-section h3 {
+  color: #333 !important;
+  margin-bottom: 15px;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+
+.loader {
+  width: 50px;
+  padding: 8px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #25b09b;
+  --_m: 
+    conic-gradient(#0000 10%,#000),
+    linear-gradient(#000 0 0) content-box;
+  -webkit-mask: var(--_m);
+          mask: var(--_m);
+  -webkit-mask-composite: source-out;
+          mask-composite: subtract;
+  animation: l3 1s infinite linear;
+}
+@keyframes l3 {to{transform: rotate(1turn)}}

--- a/src/pages/GitHubProfileAnalyzer.jsx
+++ b/src/pages/GitHubProfileAnalyzer.jsx
@@ -1,0 +1,612 @@
+import { useState } from 'react';
+import { fetchProfileData, fetchRepoStats, fetchRecentActivity, calculateLanguageUsage, sortRepos, filterRepos, fetchContributionCalendar, getTopLanguages, calculateRepoStats, formatDate, formatNumber, getContributionLevel, setGitHubToken } from '../utilities/githubUtils';
+import ErrorMessage from '../components/ErrorMessage';
+import './GitHubProfileAnalyzer.css';
+
+const GitHubProfileAnalyzer = () => {
+  const [showTokenModal, setShowTokenModal] = useState(false);
+  const [userToken, setUserToken] = useState('');
+  const [username, setUsername] = useState('');
+  const [profile, setProfile] = useState(null);
+  const [repos, setRepos] = useState([]);
+  const [activity, setActivity] = useState(null);
+  const [contributionCalendar, setContributionCalendar] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [sortBy, setSortBy] = useState('updated');
+  const [filterLanguage, setFilterLanguage] = useState('');
+  const [languages, setLanguages] = useState([]);
+  const [compareUsername, setCompareUsername] = useState('');
+  const [compareProfile, setCompareProfile] = useState(null);
+  const [compareRepos, setCompareRepos] = useState([]);
+  const [compareActivity, setCompareActivity] = useState(null);
+  const [compareContributionCalendar, setCompareContributionCalendar] = useState(null);
+  const [showCompare, setShowCompare] = useState(false);
+  const [activeTab, setActiveTab] = useState('profile');
+
+  const handleSearch = async () => {
+    if (!username) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [profileData, repoData, activityData, calendarData] = await Promise.all([
+        fetchProfileData(username),
+        fetchRepoStats(username),
+        fetchRecentActivity(username),
+        fetchContributionCalendar(username),
+      ]);
+      setProfile(profileData);
+      setRepos(repoData);
+      setActivity(activityData);
+      setContributionCalendar(calendarData);
+      setLanguages(calculateLanguageUsage(repoData));
+      if (!profileData) {
+        setError('Profile not found');
+      }
+    } catch (err) {
+      if (err.message && err.message.includes('GitHub token is required')) {
+        setShowTokenModal(true);
+      } else {
+        setError(err.message);
+      }
+    } finally {
+      setLoading(false);
+      setTimeout(() => {
+        const contentElement = document.querySelector('.content-container');
+        if (contentElement) {
+          contentElement.scrollIntoView({ behavior: 'smooth' });
+        }
+      }, 100);
+    }
+  };
+
+  const handleCompareSearch = async () => {
+    if (!compareUsername) return;
+    setLoading(true);
+    setError('');
+    try {
+      const [profileData, repoData, activityData, calendarData] = await Promise.all([
+        fetchProfileData(compareUsername),
+        fetchRepoStats(compareUsername),
+        fetchRecentActivity(compareUsername),
+        fetchContributionCalendar(compareUsername),
+      ]);
+      setCompareProfile(profileData);
+      setCompareRepos(repoData);
+      setCompareActivity(activityData);
+      setCompareContributionCalendar(calendarData);
+    } catch (err) {
+      if (err.message && err.message.includes('GitHub token is required')) {
+        setShowTokenModal(true);
+      } else {
+        setError(err.message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTokenSubmit = (e) => {
+    e.preventDefault();
+    if (userToken.trim()) {
+      setGitHubToken(userToken.trim());
+      setShowTokenModal(false);
+      setError('');
+      // Retry last search after token is set
+      if (username) handleSearch();
+      if (compareUsername) handleCompareSearch();
+    }
+  };
+
+  const sortedRepos = sortRepos(filterRepos(repos, filterLanguage), sortBy);
+  const repoStats = calculateRepoStats(repos);
+  const topLanguages = getTopLanguages(languages);
+
+  const compareSortedRepos = sortRepos(filterRepos(compareRepos, filterLanguage), sortBy);
+  const compareRepoStats = calculateRepoStats(compareRepos);
+  const compareTopLanguages = getTopLanguages(calculateLanguageUsage(compareRepos));
+
+  return (
+    <div className="github-profile-analyzer">
+      {showTokenModal && (
+        <div className="token-modal-overlay">
+          <div className="token-modal">
+            <h2>GitHub Token Required</h2>
+            <p>Please enter your GitHub Personal Access Token to continue.</p>
+            <p>
+              Need help? <a href="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token" target="_blank" rel="noopener noreferrer">Learn how to create a GitHub token</a>
+            </p>
+            <form onSubmit={handleTokenSubmit}>
+              <input
+                type="password"
+                value={userToken}
+                onChange={e => setUserToken(e.target.value)}
+                placeholder="Paste your GitHub token here"
+                className="search-input"
+                required
+              />
+              <button type="submit" className="search-button">Submit Token</button>
+            </form>
+          </div>
+        </div>
+      )}
+      <div className="hero-section">
+        <h1 className="main-title">GitHub Profile Analyzer</h1>
+        <p className="subtitle">Discover, analyze, and compare GitHub profiles with advanced stats and insights</p>
+        <div className="search-container">
+          <div className="search-bar">
+            <input
+              type="text"
+              placeholder="Enter GitHub username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
+              className="search-input"
+            />
+            <button onClick={handleSearch} className="search-button">Search</button>
+          </div>
+          <div className="compare-toggle">
+            <label>
+              <input
+                type="checkbox"
+                checked={showCompare}
+                onChange={(e) => setShowCompare(e.target.checked)}
+              />
+              Compare Profiles
+            </label>
+          </div>
+          {showCompare && (
+            <div className="compare-search">
+              <input
+                type="text"
+                placeholder="Enter second GitHub username"
+                value={compareUsername}
+                onChange={(e) => setCompareUsername(e.target.value)}
+                onKeyPress={(e) => e.key === 'Enter' && handleCompareSearch()}
+                className="search-input"
+              />
+              <button onClick={handleCompareSearch} className="search-button">Compare</button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {loading && (
+        <div className="loading-overlay">
+          <div className="loading-container">
+            <div className="loader"></div>
+            <p className='legend-color very-high subtitle'>Loading GitHub profile...</p>
+          </div>
+        </div>
+      )}
+
+      {(profile || error) && (
+        <div className="content-container">
+          {error && <ErrorMessage error={error} />}
+          {profile && (
+            <>
+              <div className="tabs">
+                <button className={activeTab === 'profile' ? 'active' : ''} onClick={() => setActiveTab('profile')}>Profile</button>
+                <button className={activeTab === 'repos' ? 'active' : ''} onClick={() => setActiveTab('repos')}>Repositories</button>
+                <button className={activeTab === 'stats' ? 'active' : ''} onClick={() => setActiveTab('stats')}>Stats</button>
+                <button className={activeTab === 'activity' ? 'active' : ''} onClick={() => setActiveTab('activity')}>Activity</button>
+                <button className={activeTab === 'calendar' ? 'active' : ''} onClick={() => setActiveTab('calendar')}>Contributions</button>
+                {showCompare && <button className={activeTab === 'compare' ? 'active' : ''} onClick={() => setActiveTab('compare')}>Compare</button>}
+              </div>
+
+              {activeTab === 'profile' && (
+                <div className="tab-content">
+                  {showCompare && compareProfile ? (
+                    <div className="compare-container">
+                      <div className="profile-section">
+                        <h3>{profile.name || profile.login}</h3>
+                        <ProfileHeader profile={profile} />
+                      </div>
+                      <div className="profile-section">
+                        <h3>{compareProfile.name || compareProfile.login}</h3>
+                        <ProfileHeader profile={compareProfile} isCompare />
+                      </div>
+                    </div>
+                  ) : (
+                    <ProfileHeader profile={profile} />
+                  )}
+                </div>
+              )}
+
+              {activeTab === 'repos' && (
+                <div className="tab-content">
+                  {showCompare && compareProfile ? (
+                    <div className="compare-container">
+                      <div className="profile-section">
+                        <h3>{profile.name || profile.login}'s Repositories</h3>
+                        <RepoList
+                          repos={sortedRepos}
+                          sortBy={sortBy}
+                          setSortBy={setSortBy}
+                          filterLanguage={filterLanguage}
+                          setFilterLanguage={setFilterLanguage}
+                          allLanguages={languages.map(l => l.language)}
+                        />
+                      </div>
+                      <div className="profile-section">
+                        <h3>{compareProfile.name || compareProfile.login}'s Repositories</h3>
+                        <RepoList
+                          repos={compareSortedRepos}
+                          sortBy={sortBy}
+                          setSortBy={setSortBy}
+                          filterLanguage={filterLanguage}
+                          setFilterLanguage={setFilterLanguage}
+                          allLanguages={calculateLanguageUsage(compareRepos).map(l => l.language)}
+                          isCompare
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <RepoList
+                      repos={sortedRepos}
+                      sortBy={sortBy}
+                      setSortBy={setSortBy}
+                      filterLanguage={filterLanguage}
+                      setFilterLanguage={setFilterLanguage}
+                      allLanguages={languages.map(l => l.language)}
+                    />
+                  )}
+                </div>
+              )}
+
+              {activeTab === 'stats' && (
+                <div className="tab-content">
+                  {showCompare && compareProfile ? (
+                    <div className="compare-container">
+                      <div className="profile-section">
+                        <h3>{profile.name || profile.login}'s Stats</h3>
+                        <StatsPanel repoStats={repoStats} activity={activity} topLanguages={topLanguages} />
+                        <LanguageChart languages={languages} />
+                      </div>
+                      <div className="profile-section">
+                        <h3>{compareProfile.name || compareProfile.login}'s Stats</h3>
+                        <StatsPanel repoStats={compareRepoStats} activity={compareActivity} topLanguages={compareTopLanguages} isCompare />
+                        <LanguageChart languages={calculateLanguageUsage(compareRepos)} isCompare />
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <StatsPanel repoStats={repoStats} activity={activity} topLanguages={topLanguages} />
+                      <LanguageChart languages={languages} />
+                    </>
+                  )}
+                </div>
+              )}
+
+              {activeTab === 'activity' && (
+                <div className="tab-content">
+                  {showCompare && compareProfile ? (
+                    <div className="compare-container">
+                      <div className="profile-section">
+                        <h3>{profile.name || profile.login}'s Activity</h3>
+                        <ActivityFeed activity={activity} />
+                      </div>
+                      <div className="profile-section">
+                        <h3>{compareProfile.name || compareProfile.login}'s Activity</h3>
+                        <ActivityFeed activity={compareActivity} isCompare />
+                      </div>
+                    </div>
+                  ) : (
+                    <ActivityFeed activity={activity} />
+                  )}
+                </div>
+              )}
+
+              {activeTab === 'calendar' && (
+                <div className="tab-content">
+                  <ContributionCalendar calendar={contributionCalendar} />
+                  {showCompare && compareProfile && <ContributionCalendar calendar={compareContributionCalendar} isCompare />}
+                </div>
+              )}
+
+              {activeTab === 'compare' && showCompare && (
+                <div className="tab-content">
+                  <CompareProfiles profile1={profile} profile2={compareProfile} repoStats1={repoStats} repoStats2={compareRepoStats} />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ProfileHeader = ({ profile, isCompare = false }) => (
+  <div className={`profile-header ${isCompare ? 'compare' : ''}`}>
+    <div className="profile-avatar">
+      <img src={profile.avatarUrl} alt={profile.name} className="avatar-image" />
+      <div className="avatar-overlay"></div>
+    </div>
+    <div className="profile-info">
+      <h2 className="profile-name">{profile.name || profile.login}</h2>
+      <p className="profile-username">@{profile.login}</p>
+      <p className="profile-bio">{profile.bio}</p>
+      <div className="profile-details">
+        <div className="detail-item">
+          <span className="detail-icon">📍</span>
+          <span>{profile.location || 'Not specified'}</span>
+        </div>
+        <div className="detail-item">
+          <span className="detail-icon">🏢</span>
+          <span>{profile.company || 'Not specified'}</span>
+        </div>
+        <div className="detail-item">
+          <span className="detail-icon">🔗</span>
+          <a href={profile.url} target="_blank" rel="noopener noreferrer" className="profile-link">View Profile</a>
+        </div>
+      </div>
+      <div className="profile-stats">
+        <div className="stat-card">
+          <span className="stat-number">{formatNumber(profile.followers.totalCount)}</span>
+          <span className="stat-label">Followers</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{formatNumber(profile.following.totalCount)}</span>
+          <span className="stat-label">Following</span>
+        </div>
+        <div className="stat-card">
+          <span className="stat-number">{formatNumber(profile.repositories.totalCount)}</span>
+          <span className="stat-label">Repositories</span>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const StatsPanel = ({ repoStats, activity, topLanguages, isCompare = false }) => (
+  <div className={`stats-panel ${isCompare ? 'compare' : ''}`}>
+    <h3 className="panel-title">Advanced Stats</h3>
+    <div className="stats-grid">
+      <div className="stat-item">
+        <span className="stat-value">{formatNumber(repoStats.totalStars)}</span>
+        <span className="stat-desc">Total Stars</span>
+      </div>
+      <div className="stat-item">
+        <span className="stat-value">{formatNumber(repoStats.totalForks)}</span>
+        <span className="stat-desc">Total Forks</span>
+      </div>
+      <div className="stat-item">
+        <span className="stat-value">{activity?.contributionsCollection?.totalCommitContributions || 0}</span>
+        <span className="stat-desc">Commits (Last Year)</span>
+      </div>
+      <div className="stat-item">
+        <span className="stat-value">{activity?.contributionsCollection?.totalPullRequestContributions || 0}</span>
+        <span className="stat-desc">PRs (Last Year)</span>
+      </div>
+      <div className="stat-item">
+        <span className="stat-value">{activity?.contributionsCollection?.totalIssueContributions || 0}</span>
+        <span className="stat-desc">Issues (Last Year)</span>
+      </div>
+      <div className="stat-item">
+        <span className="stat-value">{repoStats.averageStars.toFixed(1)}</span>
+        <span className="stat-desc">Avg Stars/Repo</span>
+      </div>
+    </div>
+    {repoStats.mostStarred && (
+      <div className="highlight-repo">
+        <h4>Most Starred Repository</h4>
+        <p>{repoStats.mostStarred.name} ({formatNumber(repoStats.mostStarred.stargazerCount)} stars)</p>
+      </div>
+    )}
+    {repoStats.mostForked && (
+      <div className="highlight-repo">
+        <h4>Most Forked Repository</h4>
+        <p>{repoStats.mostForked.name} ({formatNumber(repoStats.mostForked.forkCount)} forks)</p>
+      </div>
+    )}
+    <div className="top-languages">
+      <h4>Top Languages</h4>
+      <ul>
+        {topLanguages.map((lang, index) => (
+          <li key={lang.language} className={`lang-item lang-${index + 1}`}>
+            <span className="lang-name">{lang.language}</span>
+            <span className="lang-count">{lang.count} repos</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </div>
+);
+
+const LanguageChart = ({ languages, isCompare = false }) => {
+  const maxCount = Math.max(...languages.map(l => l.count));
+  const colors = ['#ff6b6b', '#4ecdc4', '#45b7d1', '#96ceb4', '#ffeaa7', '#dda0dd', '#98d8c8'];
+  return (
+    <div className={`language-chart ${isCompare ? 'compare' : ''}`}>
+      <h3 className="chart-title">Language Usage</h3>
+      <div className="chart-container">
+        <svg width="500" height="300" className="bar-chart">
+          {languages.map((lang, index) => {
+            const height = (lang.count / maxCount) * 200;
+            const y = 250 - height;
+            return (
+              <g key={lang.language}>
+                <rect
+                  x={index * 60 + 20}
+                  y={y}
+                  width="40"
+                  height={height}
+                  fill={colors[index % colors.length]}
+                  className="bar"
+                />
+                <text x={index * 60 + 40} y={y - 10} textAnchor="middle" className="bar-label">
+                  {lang.language}
+                </text>
+                <text x={index * 60 + 40} y={y + height + 20} textAnchor="middle" className="bar-value">
+                  {lang.count}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <div className="legend">
+        {languages.map((lang, index) => (
+          <div key={lang.language} className="legend-item">
+            <span className="legend-color" style={{ backgroundColor: colors[index % colors.length] }}></span>
+            <span>{lang.language}: {lang.count}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const RepoList = ({ repos, sortBy, setSortBy, filterLanguage, setFilterLanguage, allLanguages, isCompare = false }) => (
+  <div className={`repo-list ${isCompare ? 'compare' : ''}`}>
+    <h3 className="panel-title">Repositories</h3>
+    <div className="controls">
+      <div className="control-group">
+        <label>Sort by:</label>
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value)} className="control-select">
+          <option value="updated">Updated</option>
+          <option value="stars">Stars</option>
+          <option value="forks">Forks</option>
+        </select>
+      </div>
+      <div className="control-group">
+        <label>Filter by language:</label>
+        <select value={filterLanguage} onChange={(e) => setFilterLanguage(e.target.value)} className="control-select">
+          <option value="">All Languages</option>
+          {allLanguages.map(lang => <option key={lang} value={lang}>{lang}</option>)}
+        </select>
+      </div>
+    </div>
+    <div className="repo-grid">
+      {repos.map(repo => (
+        <div key={repo.name} className="repo-card">
+          <div className="repo-header">
+            <h4 className="repo-name">
+              <a href={repo.url} target="_blank" rel="noopener noreferrer">{repo.name}</a>
+            </h4>
+            <span className="repo-language">{repo.primaryLanguage?.name || 'N/A'}</span>
+          </div>
+          <p className="repo-description">{repo.description}</p>
+          <div className="repo-stats">
+            <span className="repo-stat">⭐ {formatNumber(repo.stargazerCount)}</span>
+            <span className="repo-stat">🍴 {formatNumber(repo.forkCount)}</span>
+            <span className="repo-stat">📅 {formatDate(repo.updatedAt)}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const ActivityFeed = ({ activity, isCompare = false }) => (
+  <div className={`activity-feed ${isCompare ? 'compare' : ''}`}>
+    <h3 className="panel-title">Recent Activity</h3>
+    <div className="activity-sections">
+      <div className="activity-section">
+        <h4>Recent Pull Requests</h4>
+        <ul className="activity-list">
+          {activity?.pullRequests?.nodes?.map(pr => (
+            <li key={pr.url} className="activity-item">
+              <a href={pr.url} target="_blank" rel="noopener noreferrer" className="activity-link">{pr.title}</a>
+              <span className="activity-date">{formatDate(pr.createdAt)}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="activity-section">
+        <h4>Recent Issues</h4>
+        <ul className="activity-list">
+          {activity?.issues?.nodes?.map(issue => (
+            <li key={issue.url} className="activity-item">
+              <a href={issue.url} target="_blank" rel="noopener noreferrer" className="activity-link">{issue.title}</a>
+              <span className="activity-date">{formatDate(issue.createdAt)}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="activity-section">
+        <h4>Top Contributing Repositories</h4>
+        <ul className="activity-list">
+          {activity?.contributionsCollection?.commitContributionsByRepository
+            ?.sort((a, b) => b.contributions.totalCount - a.contributions.totalCount)
+            ?.slice(0, 5)
+            .map(contrib => (
+              <li key={contrib.repository.name} className="activity-item">
+                <span className="activity-repo">{contrib.repository.name}</span>
+                <span className="activity-count">{contrib.contributions.totalCount} commits</span>
+              </li>
+            ))}
+        </ul>
+      </div>
+    </div>
+  </div>
+);
+
+const ContributionCalendar = ({ calendar, isCompare = false }) => {
+  if (!calendar) return <div>No contribution data available</div>;
+
+  const weeks = calendar.weeks.slice(-52); // Last 52 weeks
+  const maxContributions = Math.max(...weeks.flatMap(w => w.contributionDays.map(d => d.contributionCount)));
+
+  return (
+    <div className={`contribution-calendar ${isCompare ? 'compare' : ''}`}>
+      <h3 className="panel-title">Contribution Calendar</h3>
+      <p className="calendar-total">Total contributions in the last year: {formatNumber(calendar.totalContributions)}</p>
+      <div className="calendar-grid">
+        {weeks.map((week, weekIndex) => (
+          <div key={weekIndex} className="calendar-week">
+            {week.contributionDays.map((day, dayIndex) => (
+              <div
+                key={day.date}
+                className={`calendar-day ${getContributionLevel(day.contributionCount)}`}
+                title={`${day.contributionCount} contributions on ${formatDate(day.date)}`}
+              ></div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="calendar-legend">
+        <span>Less</span>
+        <div className="legend-colors">
+          <div className="legend-color none"></div>
+          <div className="legend-color low"></div>
+          <div className="legend-color medium"></div>
+          <div className="legend-color high"></div>
+          <div className="legend-color very-high"></div>
+        </div>
+        <span>More</span>
+      </div>
+    </div>
+  );
+};
+
+const CompareProfiles = ({ profile1, profile2, repoStats1, repoStats2 }) => (
+  <div className="compare-profiles">
+    <h3 className="panel-title">Profile Comparison</h3>
+    <div className="compare-grid">
+      <div className="compare-item">
+        <h4>{profile1.name || profile1.login}</h4>
+        <div className="compare-stats">
+          <p>Followers: {formatNumber(profile1.followers.totalCount)}</p>
+          <p>Following: {formatNumber(profile1.following.totalCount)}</p>
+          <p>Repos: {formatNumber(profile1.repositories.totalCount)}</p>
+          <p>Total Stars: {formatNumber(repoStats1.totalStars)}</p>
+          <p>Total Forks: {formatNumber(repoStats1.totalForks)}</p>
+        </div>
+      </div>
+      <div className="compare-item">
+        <h4>{profile2.name || profile2.login}</h4>
+        <div className="compare-stats">
+          <p>Followers: {formatNumber(profile2.followers.totalCount)}</p>
+          <p>Following: {formatNumber(profile2.following.totalCount)}</p>
+          <p>Repos: {formatNumber(profile2.repositories.totalCount)}</p>
+          <p>Total Stars: {formatNumber(repoStats2.totalStars)}</p>
+          <p>Total Forks: {formatNumber(repoStats2.totalForks)}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default GitHubProfileAnalyzer;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -35,7 +35,8 @@ const dashboards = [
   { path: '/covid', title: 'COVID-19 Stats', desc: 'Global & country data' },
   { path: '/pokedex', title: 'Pokédex', desc: 'Explore Pokémon species' },
   { path: '/taskflow', title: 'Task Flow Board', desc: 'Visual task management with nodes' },
-   { path: '/contributors', title: 'Contributor Wall', desc: 'Our Contributors' },
+  { path: '/github-profile-analyzer', title: 'GitHub Profile Analyzer', desc: 'Analyze GitHub profiles and repositories' },
+  { path: '/contributors', title: 'Contributor Wall', desc: 'Our Contributors' },
    
 ];
 

--- a/src/utilities/githubUtils.js
+++ b/src/utilities/githubUtils.js
@@ -1,0 +1,262 @@
+let GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN || null;
+
+export function setGitHubToken(token) {
+  GITHUB_TOKEN = token;
+}
+
+const GITHUB_GRAPHQL_URL = 'https://api.github.com/graphql';
+
+export async function fetchProfileData(username) {
+  const query = `
+    query($username: String!) {
+      user(login: $username) {
+        avatarUrl
+        name
+        login
+        bio
+        location
+        company
+        followers {
+          totalCount
+        }
+        following {
+          totalCount
+        }
+        repositories {
+          totalCount
+        }
+        url
+      }
+    }
+  `;
+
+  if (!GITHUB_TOKEN) throw new Error('GitHub token is required. Please provide a valid token.');
+  const response = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables: { username } }),
+  });
+
+  const data = await response.json();
+  if (data.errors) throw new Error(data.errors[0].message);
+  return data.data.user;
+}
+
+export async function fetchRepoStats(username) {
+  const query = `
+    query($username: String!, $first: Int!) {
+      user(login: $username) {
+        repositories(first: $first, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            name
+            description
+            stargazerCount
+            forkCount
+            primaryLanguage {
+              name
+            }
+            updatedAt
+            url
+          }
+        }
+      }
+    }
+  `;
+
+  if (!GITHUB_TOKEN) throw new Error('GitHub token is required. Please provide a valid token.');
+  const response = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables: { username, first: 100 } }),
+  });
+
+  const data = await response.json();
+  if (data.errors) throw new Error(data.errors[0].message);
+  return data.data.user.repositories.nodes;
+}
+
+export async function fetchRecentActivity(username) {
+  // Fetch recent commits, PRs, issues
+  const query = `
+    query($username: String!) {
+      user(login: $username) {
+        contributionsCollection {
+          totalCommitContributions
+          totalPullRequestContributions
+          totalIssueContributions
+          commitContributionsByRepository {
+            repository {
+              name
+            }
+            contributions {
+              totalCount
+            }
+          }
+        }
+        pullRequests(first: 5, orderBy: {field: CREATED_AT, direction: DESC}) {
+          nodes {
+            title
+            url
+            createdAt
+          }
+        }
+        issues(first: 5, orderBy: {field: CREATED_AT, direction: DESC}) {
+          nodes {
+            title
+            url
+            createdAt
+          }
+        }
+      }
+    }
+  `;
+
+  if (!GITHUB_TOKEN) throw new Error('GitHub token is required. Please provide a valid token.');
+  const response = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables: { username } }),
+  });
+
+  const data = await response.json();
+  if (data.errors) throw new Error(data.errors[0].message);
+  return data.data.user;
+}
+
+export function calculateLanguageUsage(repos) {
+  const languageMap = {};
+  repos.forEach(repo => {
+    const lang = repo.primaryLanguage?.name || 'Unknown';
+    languageMap[lang] = (languageMap[lang] || 0) + 1;
+  });
+  return Object.entries(languageMap).map(([language, count]) => ({ language, count }));
+}
+
+export function sortRepos(repos, sortBy) {
+  return [...repos].sort((a, b) => {
+    switch (sortBy) {
+      case 'stars':
+        return b.stargazerCount - a.stargazerCount;
+      case 'forks':
+        return b.forkCount - a.forkCount;
+      case 'updated':
+        return new Date(b.updatedAt) - new Date(a.updatedAt);
+      default:
+        return 0;
+    }
+  });
+}
+
+export function filterRepos(repos, language) {
+  if (!language) return repos;
+  return repos.filter(repo => repo.primaryLanguage?.name === language);
+}
+
+export async function fetchContributionCalendar(username) {
+  const query = `
+    query($username: String!) {
+      user(login: $username) {
+        contributionsCollection {
+          contributionCalendar {
+            totalContributions
+            weeks {
+              contributionDays {
+                contributionCount
+                date
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  if (!GITHUB_TOKEN) throw new Error('GitHub token is required. Please provide a valid token.');
+  const response = await fetch(GITHUB_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables: { username } }),
+  });
+
+  const data = await response.json();
+  if (data.errors) throw new Error(data.errors[0].message);
+  return data.data.user.contributionsCollection.contributionCalendar;
+}
+
+export function getTopLanguages(languages, topN = 5) {
+  return languages.sort((a, b) => b.count - a.count).slice(0, topN);
+}
+
+export function calculateRepoStats(repos) {
+  const stats = {
+    totalStars: 0,
+    totalForks: 0,
+    totalSize: 0,
+    languages: {},
+    mostStarred: null,
+    mostForked: null,
+    averageStars: 0,
+    averageForks: 0,
+  };
+
+  repos.forEach(repo => {
+    stats.totalStars += repo.stargazerCount;
+    stats.totalForks += repo.forkCount;
+    stats.totalSize += repo.size || 0;
+    const lang = repo.primaryLanguage?.name || 'Unknown';
+    stats.languages[lang] = (stats.languages[lang] || 0) + 1;
+
+    if (!stats.mostStarred || repo.stargazerCount > stats.mostStarred.stargazerCount) {
+      stats.mostStarred = repo;
+    }
+    if (!stats.mostForked || repo.forkCount > stats.mostForked.forkCount) {
+      stats.mostForked = repo;
+    }
+  });
+
+  stats.averageStars = stats.totalStars / repos.length;
+  stats.averageForks = stats.totalForks / repos.length;
+
+  return stats;
+}
+
+export function formatDate(dateString) {
+  if (!dateString) return 'N/A';
+  try {
+    const date = new Date(dateString);
+    // Check if date is valid
+    if (isNaN(date.getTime())) return 'Invalid Date';
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  } catch (error) {
+    console.error('Error formatting date:', error, dateString);
+    return 'Error';
+  }
+}
+
+export function formatNumber(num) {
+  return num.toLocaleString();
+}
+
+export function getContributionLevel(count) {
+  if (count === 0) return 'none';
+  if (count < 5) return 'low';
+  if (count < 10) return 'medium';
+  if (count < 20) return 'high';
+  return 'very-high';
+}


### PR DESCRIPTION
Closes #127
This PR introduces the GitHub Profile Analyzer dashboard:

- Enables searching and analyzing GitHub profiles with advanced stats and charts - view GitHub profile stats, repositories, and pull request activity at a glance
- Allows comparison between two profiles.
- Adds a modal for GitHub token input, including a help link.
- Improves UI/UX and error handling.
- Adds a home page card for the feature.
- Updates documentation to reflect the new dashboard and contribution ideas.

<img width="955" height="810" alt="image" src="https://github.com/user-attachments/assets/f470992e-f625-45a3-b8b1-ee8a2b2999c5" />



Hi @venisha-kalola please add the github token as per this [managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with the key name `VITE_GITHUB_TOKEN` in the environment varaibles

